### PR TITLE
Feat/#57 파티 수정기능 구현

### DIFF
--- a/PodongPodong/PodongPodong/Presentations/PartyCreate/ViewModels/PartyCreateViewModel.swift
+++ b/PodongPodong/PodongPodong/Presentations/PartyCreate/ViewModels/PartyCreateViewModel.swift
@@ -10,38 +10,62 @@ import Observation
 
 @Observable
 final class PartyCreateViewModel {
+    // 편집 모드 관련
+    var isEditMode: Bool = false
+    var editingParty: Party? = nil
+
     var selectedOrderType: OrderType? = nil
     var title: String = ""
     var selectedCategory: FoodCategory? = nil
     var recruitmentCount = 2
     var selectedPurchaseChannle: PurchaseChannel? = nil
     var purchaseLocation: String = ""
-    
+
     var totalPrice: Int? = nil
     var selectedWeightAndCount: WeightAndCount? = nil
     var amount: Int? = nil
-    
+
     var selectedDate: String = ""
     var selectedTime: String = ""
     var selectedPlace: String = ""
     var description: String = ""
-    
+
+
+    // 상태관련
     var errorMessage: String? = nil
     var isLoading: Bool = false
     var isCreateSuccess: Bool = false
+    var isUpdateSuccess: Bool = false
+
+    // MARK: - 편집 제한 관련
+        var canEditRecruitmentCount: Bool {
+            guard let party = editingParty else { return true }
+            
+            return party.member.isEmpty
+        }
+        
+        var canEditOrderType: Bool {
+            
+            return !isEditMode
+        }
+        
+        var editingRestrictionMessage: String? {
+            if isEditMode && !canEditRecruitmentCount {
+                return "이미 참여한 멤버가 있어 모집 인원을 변경할 수 없습니다."
+            }
+            return nil
+        }
     
+    
+    // MARK: - 계산 프로퍼티
     var isButtonEnabled: Bool {
         let baseConditions =
-        selectedOrderType != nil &&
-        !title.isEmpty &&
-        selectedCategory != nil &&
-        selectedPurchaseChannle != nil
-        
+            selectedOrderType != nil && !title.isEmpty
+            && selectedCategory != nil && selectedPurchaseChannle != nil
+
         let groupPurchaseExtraConditions =
-        totalPrice != nil &&
-        selectedWeightAndCount != nil &&
-        amount != nil
-        
+            totalPrice != nil && selectedWeightAndCount != nil && amount != nil
+
         switch selectedOrderType {
         case .groupPurchase:
             return baseConditions && groupPurchaseExtraConditions
@@ -51,8 +75,65 @@ final class PartyCreateViewModel {
             return false
         }
     }
+
+    var navigationTitle: String {
+        return isEditMode ? "파티 수정하기" : "파티 만들기"
+    }
+
+    var buttonTitle: String {
+        return isEditMode ? "수정하기" : "생성하기"
+    }
+
+    var loadingMessage: String {
+        return isEditMode ? "수정 중..." : "생성 중..."
+    }
+
+    // MARK: - 초기화
+    init() {
+        // 생성 모드로 기본 초기화
+    }
+
+    init(party: Party) {
+        // 편집 모드로 초기화
+        loadPartyData(party)
+    }
+
+    // MARK: - 편집 모드 관련 메서드
+    func loadPartyData(_ party: Party) {
+            isEditMode = true
+            editingParty = party
+            
+            selectedOrderType = party.orderType
+            title = party.title
+            selectedCategory = party.category
+            recruitmentCount = party.recruitmentCount
+            selectedPurchaseChannle = party.purchaseChannel
+            purchaseLocation = party.purchaseLocation
+            
+            totalPrice = party.totalPrice
+            selectedWeightAndCount = party.weightAndCount
+            amount = party.amount
+            
+            selectedDate = party.appointment.date ?? ""
+            selectedTime = party.appointment.time ?? ""
+            selectedPlace = party.appointment.location ?? ""
+            description = party.description ?? ""
+        }
     
-    func createParty(){
+    
+    
+    
+    // MARK: - 액션 메서드
+    func performMainAction() {
+            if isEditMode {
+                updateParty()
+            } else {
+                createParty()
+            }
+        }
+    
+    
+    func createParty() {
         let party = Party(
             writen: DummyData.user,
             title: title,
@@ -72,16 +153,74 @@ final class PartyCreateViewModel {
             description: description,
             chatURL: ""
         )
-        
+
         Task {
             do {
                 isLoading = true
                 let _ = try await FirestoreManager.shared.create(party)
                 isLoading = false
+                isCreateSuccess = true
             } catch {
+                isLoading = false
                 errorMessage = error.localizedDescription
             }
-            isCreateSuccess = true
         }
     }
+    
+    func updateParty() {
+            guard var party = editingParty else {
+                errorMessage = "수정할 파티 정보를 찾을 수 없습니다."
+                return
+            }
+            
+            // 파티 데이터 업데이트
+            party.title = title
+            party.category = selectedCategory ?? party.category
+            party.recruitmentCount = recruitmentCount
+            party.purchaseChannel = selectedPurchaseChannle ?? party.purchaseChannel
+            party.purchaseLocation = purchaseLocation
+            party.totalPrice = totalPrice ?? party.totalPrice
+            party.weightAndCount = selectedWeightAndCount ?? party.weightAndCount
+            party.amount = amount ?? party.amount
+            party.appointment = Party.Appointment(
+                date: selectedDate.isEmpty ? nil : selectedDate,
+                time: selectedTime.isEmpty ? nil : selectedTime,
+                location: selectedPlace.isEmpty ? nil : selectedPlace
+            )
+            party.description = description.isEmpty ? nil : description
+            party.updatedAt = Date()
+            
+            Task {
+                do {
+                    isLoading = true
+                    try await FirestoreManager.shared.update(party)
+                    isLoading = false
+                    isUpdateSuccess = true
+                } catch {
+                    isLoading = false
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+        
+        // MARK: - 상태 리셋
+        func resetForm() {
+            selectedOrderType = nil
+            title = ""
+            selectedCategory = nil
+            recruitmentCount = 2
+            selectedPurchaseChannle = nil
+            purchaseLocation = ""
+            totalPrice = nil
+            selectedWeightAndCount = nil
+            amount = nil
+            selectedDate = ""
+            selectedTime = ""
+            selectedPlace = ""
+            description = ""
+            errorMessage = nil
+            isLoading = false
+            isCreateSuccess = false
+            isUpdateSuccess = false
+        }
 }

--- a/PodongPodong/PodongPodong/Presentations/PartyCreate/Views/Components/DescriptionView+.swift
+++ b/PodongPodong/PodongPodong/Presentations/PartyCreate/Views/Components/DescriptionView+.swift
@@ -10,13 +10,30 @@ import SwiftUI
 extension PartyCreateView {
     struct DescriptionView: View {
         @Binding var description: String
-        
-        var body : some View{
-            VStack{
-                Text("설명 (선택)")
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.leading, 16)
-                    .font(.pretendardMedium16)
+        var isEditMode: Bool = false
+        @FocusState private var isTextEditorFocused: Bool
+
+        var body: some View {
+            VStack(spacing: 12) {
+                HStack {
+                    Text("설명 (선택)")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.leading, 16)
+                        .font(.pretendardMedium16)
+
+                    // 편집 모드 표시
+                    if isEditMode && !description.isEmpty {
+                        Text("편집 중")
+                            .font(.pretend(type: .light, size: 12))
+                            .foregroundColor(.blue)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 2)
+                            .background(Color.blue.opacity(0.1))
+                            .cornerRadius(4)
+                    }
+                }
+                .padding(.horizontal, 16)
+
                 Text("이런 내용을 적어보세요\n-가이드라인 1\n-가이드라인2\n-가이드라인3")
                     .padding(.horizontal, 20)
                     .padding(.vertical, 12)
@@ -25,12 +42,62 @@ extension PartyCreateView {
                     .background(Color.gray10)
                     .foregroundColor(Color.gray70)
                     .font(.pretendardMedium16)
-                
-                
+
+                // 멀티라인 텍스트 입력
+                ZStack() {
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(
+                            isTextEditorFocused
+                                ? Color.blue
+                                : Color.gray50,
+                            lineWidth: isTextEditorFocused ? 2 : 1
+                        )
+                        .frame(width: 361, height: 244)
+                        .background(Color.white)
+
+                    if description.isEmpty {
+                        VStack {
+                            HStack {
+                                Text("파티를 어떻게 운영할 것인지에 대한 구체적인 정보를 적어주세요.")
+                                    .foregroundColor(.gray50)
+                                    .font(.pretendardMedium16)
+                                    .padding(.leading, 12)
+                                Spacer()
+                            }
+                            Spacer()
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.top, 12)
+                        .allowsHitTesting(false)
+                    }
+
+                    ScrollView {
+                        VStack(spacing: 0) {
+                            TextEditor(text: $description)
+                                .font(.pretendardMedium16)
+                                .foregroundColor(.black)
+                                .focused($isTextEditorFocused)
+                                .background(Color.clear)
+                                .scrollContentBackground(.hidden)
+                                .frame(minHeight: 228)
+                                .textSelection(.enabled)
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .frame(width: 361, height: 244)
+                }
+                .cornerRadius(8)
+                .animation(
+                    .easeInOut(duration: 0.2),
+                    value: isTextEditorFocused
+                )
+
                 // TODO: 멀티라인 입력 처리하기
-                TextFieldView(
-                    text: $description,
-                    placeholder: "파티를 어떻게 운영할 것인지에 대한 구체적인 정보를 적어주세요.").frame(width: 361, height: 244)
+                //                TextFieldView(
+                //                    text: $description,
+                //                    placeholder: "파티를 어떻게 운영할 것인지에 대한 구체적인 정보를 적어주세요."
+                //                ).frame(width: 361, height: 244)
             }
         }
     }

--- a/PodongPodong/PodongPodong/Presentations/PartyCreate/Views/Components/EditingOrderTypeDisplayView+.swift
+++ b/PodongPodong/PodongPodong/Presentations/PartyCreate/Views/Components/EditingOrderTypeDisplayView+.swift
@@ -1,0 +1,60 @@
+//
+//  EditModeOrderTypeDisplayView+.swift
+//  PodongPodong
+//
+//  Created by PenguinLand on 6/10/25.
+//
+
+import SwiftUI
+
+// MARK: - 편집 모드용 OrderType 표시 뷰
+extension PartyCreateView {
+    struct EditingOrderTypeDisplayView: View {
+        let orderType: OrderType
+        
+        var body: some View {
+            VStack {
+                Text("구매 방식")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.leading, 16)
+                    .font(.pretendardMedium16)
+                
+                HStack {
+                    Image(systemName: orderType == .groupPurchase ? "person.2" : "cart.fill")
+                        .foregroundColor(.gray)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(orderType.title)
+                            .font(.pretendardMedium16)
+                            .foregroundColor(.black)
+                        
+                        Text(orderType == .groupPurchase
+                             ? "여러 명이 모여 더 싸게 구매할 수 있어요."
+                             : "함께 모여 오프라인 구매처에서 장을 볼 수 있어요.")
+                            .font(.pretendardLight14)
+                            .foregroundColor(.gray70)
+                    }
+                    
+                    Spacer()
+                    
+                    Text("수정 불가")
+                        .font(.pretend(type: .light, size: 12))
+                        .foregroundColor(.gray50)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color.gray20)
+                        .cornerRadius(4)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+                .background(Color.gray10)
+                .cornerRadius(8)
+                .padding(.horizontal, 16)
+            }
+        }
+    }
+}
+
+#Preview {
+    PartyCreateView(party: DummyData.partyGroup1)
+}

--- a/PodongPodong/PodongPodong/Presentations/PartyCreate/Views/Components/RecruitmentCountView+.swift
+++ b/PodongPodong/PodongPodong/Presentations/PartyCreate/Views/Components/RecruitmentCountView+.swift
@@ -10,26 +10,41 @@ import SwiftUI
 extension PartyCreateView {
     struct RecruitmentCountView: View {
         @Binding var recruitmentCount: Int
-        
-        let minCount=2
-        let maxCount=8
-        
-        var body: some View{
-            VStack{
+        var canEdit: Bool = true
+        var restrictionMessage: String? = nil
+
+        let minCount = 2
+        let maxCount = 8
+
+        var body: some View {
+            VStack {
                 Text("모집 인원")
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.leading, 16)
                     .font(.pretendardMedium16)
-                HStack(spacing: 12){
-                    Button(action: {if recruitmentCount > minCount{recruitmentCount -= 1}}){
+
+                if let message = restrictionMessage {
+                    Text(message)
+                        .font(.pretend(type: .light, size: 12))
+                        .foregroundColor(.orange)
+                        .padding(.horizontal, 16)
+                }
+
+                HStack(spacing: 12) {
+                    Button(action: {
+                        if canEdit && recruitmentCount > minCount { recruitmentCount -= 1 }
+                    }) {
                         Text("-")
-                            .foregroundColor(recruitmentCount > minCount ? .black : Color.gray50)
-                            
+                            .foregroundColor(
+                                recruitmentCount > minCount
+                                    ? .black : Color.gray50
+                            )
+
                     }
                     .padding(.leading, 12)
-                    .frame(width : 42, height: 36, alignment: .center)
+                    .frame(width: 42, height: 36, alignment: .center)
                     .font(Font.custom("Pretendard", size: 30))
-                    
+
                     Text("\(recruitmentCount)명")
                         .font(.pretendardLight14)
                         .frame(width: 58, height: 36, alignment: .center)
@@ -37,17 +52,26 @@ extension PartyCreateView {
                         .overlay(
                             Rectangle()
                                 .inset(by: 0.5)
-                                .stroke(Color.gray50, lineWidth:1)
+                                .stroke(Color.gray50, lineWidth: 1)
                         )
-                    Button(action: {if recruitmentCount < maxCount{recruitmentCount += 1}}){
+                    Button(action: {
+                        if canEdit && recruitmentCount < maxCount { recruitmentCount += 1 }
+                    }) {
                         Text("+")
-                            .foregroundStyle(recruitmentCount < maxCount ? .black : Color.gray50)
+                            .foregroundStyle(
+                                recruitmentCount < maxCount
+                                    ? .black : Color.gray50
+                            )
                     }
+                    .disabled(!canEdit)
                     .padding(.trailing, 12)
-                    .frame(width : 42, height: 36, alignment: .center)
+                    .frame(width: 42, height: 36, alignment: .center)
                     .font(Font.custom("Pretendard", size: 30))
                 }
-                .background(RoundedRectangle(cornerRadius: 8).stroke(Color.gray50, lineWidth: 2))
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(canEdit ? Color.gray50 : Color.gray30, lineWidth: 2)
+                )
                 .frame(maxWidth: .infinity, alignment: .trailing)
                 .padding(.trailing, 16)
             }

--- a/PodongPodong/PodongPodong/Presentations/PartyCreate/Views/PartyCreateView.swift
+++ b/PodongPodong/PodongPodong/Presentations/PartyCreate/Views/PartyCreateView.swift
@@ -12,23 +12,51 @@ struct PartyCreateView: View {
 
     @State private var viewModel = PartyCreateViewModel()
     @EnvironmentObject var router: MainNavigationRouter
-    
+
+    // MARK: - 초기화
+    init() {
+        self._viewModel = State(initialValue: PartyCreateViewModel())
+    }
+
+    init(party: Party) {
+        self._viewModel = State(
+            initialValue: PartyCreateViewModel(party: party)
+        )
+    }
+
     var body: some View {
         ZStack {
-            ScrollView{
-                VStack(spacing: 38){
-                    OrderTypeView(selectedOrderType: $viewModel.selectedOrderType)
+            ScrollView {
+                VStack(spacing: 38) {
+                    // 편집 모드에서는 구매 방식 변경 불가
+                    if !viewModel.isEditMode {
+                        OrderTypeView(
+                            selectedOrderType: $viewModel.selectedOrderType
+                        )
+                    } else {
+                        EditingOrderTypeDisplayView(
+                            orderType: viewModel.selectedOrderType
+                                ?? .groupPurchase
+                        )
+                    }
+
                     TitleView(title: $viewModel.title)
                     CategoryView(selectedCategory: $viewModel.selectedCategory)
-                    RecruitmentCountView(recruitmentCount: $viewModel.recruitmentCount)
+                    RecruitmentCountView(
+                        recruitmentCount: $viewModel.recruitmentCount,
+                        canEdit: viewModel.canEditRecruitmentCount,
+                        restrictionMessage: viewModel.editingRestrictionMessage
+                    )
                     PurchaseLocationView(
-                        selectedPurchaseChannel: $viewModel.selectedPurchaseChannle,
+                        selectedPurchaseChannel: $viewModel
+                            .selectedPurchaseChannle,
                         purchaseLocation: $viewModel.purchaseLocation
                     )
                     if viewModel.selectedOrderType == .groupPurchase {
                         PriceAndWeightView(
                             totalPrice: $viewModel.totalPrice,
-                            selectedWeightAndCount: $viewModel.selectedWeightAndCount,
+                            selectedWeightAndCount: $viewModel
+                                .selectedWeightAndCount,
                             amount: $viewModel.amount
                         )
                     }
@@ -37,47 +65,69 @@ struct PartyCreateView: View {
                         selectedTime: $viewModel.selectedTime,
                         selectedPlace: $viewModel.selectedPlace
                     )
-                    DescriptionView(description: $viewModel.description)
+                    DescriptionView(
+                        description: $viewModel.description,
+                        isEditMode: viewModel.isEditMode
+                    )
+
+                    // 생성/편집 모드에 따라 버튼 작동
                     Button {
-                        // TODO: 생성 로직
-                        viewModel.createParty()
+                        viewModel.performMainAction()
                     } label: {
-                        ActionButtonView(title: "생성하기", isEnabled: viewModel.isButtonEnabled)
-                            .frame(width: 351)
+                        ActionButtonView(
+                            title: viewModel.buttonTitle,
+                            isEnabled: viewModel.isButtonEnabled
+                        )
+                        .frame(width: 351)
                     }
                 }
             }
             if viewModel.isLoading {
                 VStack(spacing: 16) {
-                    ProgressView("생성 중...")
+                    ProgressView(viewModel.loadingMessage)
                         .progressViewStyle(CircularProgressViewStyle())
                         .foregroundColor(.white)
                         .tint(.white)
                 }
                 .padding(24)
-                .background(RoundedRectangle(cornerRadius: 12).fill(Color.black.opacity(0.8)))
+                .background(
+                    RoundedRectangle(cornerRadius: 12).fill(
+                        Color.black.opacity(0.8)
+                    )
+                )
             }
         }
-        .navigationBarTitle("파티 만들기", displayMode: .inline)
+        .navigationBarTitle(viewModel.navigationTitle, displayMode: .inline)
         .navigationBarItems(
             leading: BackButton(dismiss: dismiss),
             trailing: EmptyView()
         )
-        .alert("에러", isPresented: Binding<Bool>(
-            get: { viewModel.errorMessage != nil },
-            set: { isPresented in
-                if !isPresented {
-                    viewModel.errorMessage = nil
+        .alert(
+            "에러",
+            isPresented: Binding<Bool>(
+                get: { viewModel.errorMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        viewModel.errorMessage = nil
+                    }
                 }
-            }
-        )) {
-            Button("확인", role: .cancel) { }
+            )
+        ) {
+            Button("확인", role: .cancel) {}
         } message: {
             Text(viewModel.errorMessage ?? "알 수 없는 에러가 발생했어요.")
         }
         .onChange(of: viewModel.isCreateSuccess) { isSuccess in
             if isSuccess {
+                dismiss()
                 // TODO: DetailView 이동
+
+            }
+        }
+        .onChange(of: viewModel.isUpdateSuccess) { isSuccess in
+            if isSuccess {
+                // 수정 완료 후 이전 화면(DetailView)으로 돌아감
+                dismiss()
             }
         }
     }
@@ -85,4 +135,8 @@ struct PartyCreateView: View {
 
 #Preview {
     PartyCreateView()
+}
+
+#Preview("편집 모드") {
+    PartyCreateView(party: DummyData.partyGroup1)
 }

--- a/PodongPodong/PodongPodong/Presentations/PartyDetail/Views/PartyDetailView.swift
+++ b/PodongPodong/PodongPodong/Presentations/PartyDetail/Views/PartyDetailView.swift
@@ -16,7 +16,7 @@ struct PartyDetailView: View {
 
     @State private var showingMoreOptions = false
     @State private var showingDeleteAlert = false
-    @State private var sort: Int = 0
+    @State private var showingEditView = false
 
     init(party: Party) {
         self.party = party
@@ -63,6 +63,16 @@ struct PartyDetailView: View {
             } message: {
                 Text("정말로 이 파티를 삭제하시겠습니까?\n삭제된 파티는 복구할 수 없습니다.")
             }
+            .navigationDestination(isPresented: $showingEditView) {
+                if let currentParty = viewModel.party {
+                    PartyCreateView(party: currentParty)
+                        .onDisappear() {
+                            Task {
+                                await viewModel.refreshPartyDetail()
+                            }
+                        }
+                }
+            }
 
             PartyDetailBottomView(viewModel: viewModel)
                 .frame(height: 30)
@@ -78,6 +88,9 @@ struct PartyDetailView: View {
             Button("확인", role: .cancel) {}
         } message: {
             Text(viewModel.errorMessage ?? "알 수 없는 오류가 발생했습니다.")
+        }
+        .task {
+            await viewModel.fetchPartyDetail()
         }
     }
 
@@ -118,7 +131,7 @@ struct PartyDetailView: View {
     private var moreOptionsButton: some View {
         Menu {
             Button {
-                // 파티 정보 수정하기 기능
+                handleEditParty()
             } label: {
                 Label("파티 수정하기", systemImage: "square.and.pencil")
             }
@@ -133,6 +146,11 @@ struct PartyDetailView: View {
                 .foregroundStyle(.black)
         }
     }
+    
+    private func handleEditParty() {
+        showingEditView = true
+    }
+    
 }
 
 #Preview {


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
파티 수정 기능 구현
- 인원 참여시 인원 수정 제한
- 구매 방식 수정 제한
  - 편집 모드에서는 구매 방식 view 다르게 보이게 구현
- 파티 상세 수정시 상태 추적하여 프레임 색상 변경
- 파티 상세화면에서 파티 수정 기능 구현
  - 수정 완료시 파티 새로고침 후 상세화면으로 다시 돌아오게끔 구현
- 파티 생성/수정에 따른 버튼 기능,타이틀 변경


## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
