### PR TITLE
fix/#77 내 파티 실제 파티 데이터로 불러오도록 수정

### DIFF
--- a/PodongPodong/PodongPodong/Presentations/MyParties/ViewModels/MyPartiesViewModel.swift
+++ b/PodongPodong/PodongPodong/Presentations/MyParties/ViewModels/MyPartiesViewModel.swift
@@ -12,16 +12,73 @@ import Observation
 final class MyPartiesViewModel {
     var selectedPartyStatus: PartyStatus = .recruiting
 
+    var isLoading: Bool = false
+    var errorMessage: String? = nil
+
     private(set) var partyList: [Party] = []
-    private var user: User = User.sampleHost
+    private var user: User? = {
+        guard
+            let data = UserDefaults.standard.data(forKey: UserDefaults.userKey),
+            let user = try? JSONDecoder().decode(User.self, from: data)
+        else {
+            return nil
+        }
+        return user
+    }()
 
     init() {
-        partyList = DummyData.allParties
+        myPartiesFetch()
     }
 
     var myParties: [Party] {
-        partyList
-            .filter { $0.member.contains { $0.id == user.id } }
+        guard let user else { return [] }
+
+        return partyList
+            .filter { party in
+                party.writen.id == user.id
+                    || party.member.contains { $0.id == user.id }
+            }
             .filter { $0.status == selectedPartyStatus }
     }
+
+    func myPartiesFetch() {
+        Task {
+            do {
+                isLoading = true
+                errorMessage = nil
+
+                // 전체 파티 데이터를 가져온 후 클라이언트에서 필터링
+                // TODO: 서버에서 사용자 관련 파티만 필터링해서 가져오도록 최적화 필요
+                let fetchedParties = try await FirestoreManager.shared.fetch(
+                    as: Party.self,
+                    .party,
+                    order: "createdAt"
+                )
+                partyList = fetchedParties
+
+                isLoading = false
+            } catch {
+                isLoading = false
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    func refreshMyParties() {
+        myPartiesFetch()
+    }
+
+    
+    func reloadUserAndRefresh() {
+            // UserDefaults에서 사용자 정보 다시 로드
+            if let data = UserDefaults.standard.data(forKey: UserDefaults.userKey),
+               let updatedUser = try? JSONDecoder().decode(User.self, from: data) {
+                user = updatedUser
+                myPartiesFetch()
+            } else {
+                user = nil
+                partyList = []
+                errorMessage = "사용자 정보를 찾을 수 없습니다. 다시 로그인해주세요."
+            }
+        }
 }

--- a/PodongPodong/PodongPodong/Presentations/MyParties/Views/MyParties+MainView.swift
+++ b/PodongPodong/PodongPodong/Presentations/MyParties/Views/MyParties+MainView.swift
@@ -11,53 +11,71 @@ extension MyPartiesView {
     struct MyPartiesMainView: View {
         @Binding var selectedTab: PartyStatus
         let myParties: [Party]
+        let refresh: () -> Void
 
         var body: some View {
             TabView(selection: $selectedTab) {
                 ForEach(PartyStatus.allCases) { tab in
-                    List {
-                        ForEach(myParties) { party in
-
-                            PartyListItem(party: party)
-                                .listRowSeparator(.hidden)
-                                .listRowInsets(
-                                    .init(
-                                        top: 15,
-                                        leading: 15,
-                                        bottom: 0,
-                                        trailing: 15
-                                    )
-                                )
-
-                            ZStack {
-                                NavigationLink {
-                                    PartyDetailView(party: party)
-                                        .navigationBarBackButtonHidden()
-                                } label: {
-                                    EmptyView()
+                    Group {
+                        if filteredParties(for: tab).isEmpty {
+                            // 빈 상태 표시
+                            VStack(spacing: 16) {
+                                Image(systemName: "person.2.slash")
+                                    .font(.system(size: 48))
+                                    .foregroundColor(.gray)
+                                Text("참여한 파티가 없습니다")
+                                    .font(.pretend(type: .medium, size: 16))
+                                    .foregroundColor(.gray)
+                                Button("새로고침") {
+                                    refresh()
                                 }
-                                .opacity(0)
-
-                                PartyListItem(party: party)
+                                .padding(.horizontal, 20)
+                                .padding(.vertical, 8)
+                                .background(Color.blue)
+                                .foregroundColor(.white)
+                                .cornerRadius(8)
                             }
-                            .listRowBackground(Color.clear)
-                            .listRowSeparator(.hidden)
-                            .listRowInsets(
-                                .init(
-                                    top: 15,
-                                    leading: 15,
-                                    bottom: 0,
-                                    trailing: 15
-                                )
-                            )
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        } else {
+                            List {
+                                ForEach(filteredParties(for: tab)) { party in
+                                    ZStack {
+                                        NavigationLink {
+                                            PartyDetailView(party: party)
+                                                .navigationBarBackButtonHidden()
+                                        } label: {
+                                            EmptyView()
+                                        }
+                                        .opacity(0)
 
+                                        PartyListItem(party: party)
+                                    }
+                                    .listRowBackground(Color.clear)
+                                    .listRowSeparator(.hidden)
+                                    .listRowInsets(
+                                        .init(
+                                            top: 15,
+                                            leading: 15,
+                                            bottom: 0,
+                                            trailing: 15
+                                        )
+                                    )
+                                }
+                            }
+                            .listStyle(PlainListStyle())
+                            .refreshable {
+                                refresh()
+                            }
                         }
                     }
-                    .listStyle(PlainListStyle())
                     .tag(tab)
                 }
             }
             .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+        }
+        // 특정 탭에 해당하는 파티들을 필터링
+        private func filteredParties(for status: PartyStatus) -> [Party] {
+            return myParties.filter { $0.status == status }
         }
     }
 }

--- a/PodongPodong/PodongPodong/Presentations/MyParties/Views/MyPartiesView.swift
+++ b/PodongPodong/PodongPodong/Presentations/MyParties/Views/MyPartiesView.swift
@@ -25,12 +25,41 @@ struct MyPartiesView: View {
                     .frame(height: 47)
                     .overlay(Divider(), alignment: .bottom)
 
-                    MyPartiesMainView(
-                        selectedTab: $viewModel.selectedPartyStatus,
-                        myParties: viewModel.myParties
-                    )
+                    if viewModel.isLoading {
+                        Spacer()
+                        ProgressView("로딩 중...")
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        Spacer()
+                    } else if let errorMessage = viewModel.errorMessage {
+                        Spacer()
+                        VStack(spacing: 16) {
+                            Image(systemName: errorMessage.contains("로그인") ? "person.fill.xmark" : "exclamationmark.triangle")
+                                .font(.system(size: 48))
+                                .foregroundColor(.gray)
+                            
+                            Text(errorMessage.contains("로그인") ? "로그인이 필요합니다" : "오류가 발생했습니다")
+                                .font(.pretend(type: .semibold, size: 16))
+                            
+                            Text(errorMessage)
+                                .font(.pretend(type: .regular, size: 14))
+                                .foregroundColor(.gray)
+                                .multilineTextAlignment(.center)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        Spacer()
+                    } else {
+                        MyPartiesMainView(
+                            selectedTab: $viewModel.selectedPartyStatus,
+                            myParties: viewModel.myParties,
+                            refresh: viewModel.refreshMyParties
+                        )
+                    }
                 }
             }
+        }
+        .onAppear {
+            // 뷰가 나타날 때 사용자 정보를 다시 확인하고 필요시 데이터 갱신
+            viewModel.reloadUserAndRefresh()
         }
     }
 }


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
실제 유저,파티 데이터를 받아와 필터링을 진행하여 참여한 파티를 보여주도록 구현하였습니다.

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
