### PR TITLE
검색한 다음 상세화면으로 내비게이션

### DIFF
--- a/PodongPodong/PodongPodong/Presentations/Search/Views/SearchList+MainView.swift
+++ b/PodongPodong/PodongPodong/Presentations/Search/Views/SearchList+MainView.swift
@@ -28,10 +28,24 @@ extension SearchView {
                     ForEach(OrderType.allCases) { tab in
                         List {
                             ForEach(parties) { party in
-                                PartyListItem(party: party)
-                                    .listRowSeparator(.hidden)
-                                    .listRowInsets(.init(top: 15, leading: 15,
-                                                         bottom: 0, trailing:15))
+                                ZStack {
+                                    NavigationLink {
+                                        // TODO: 파티 디테일 이동
+                                        PartyDetailView(party: party)
+                                            .navigationBarBackButtonHidden()
+                                    } label: {
+                                        EmptyView()
+                                    }
+                                    .opacity(0)
+                                    
+                                    PartyListItem(party: party)
+                                }
+                                .listRowBackground(Color.clear)
+                                .listRowSeparator(.hidden)
+                                .listRowInsets(.init(top: 16,
+                                                     leading: 16,
+                                                     bottom: 0,
+                                                     trailing: 16))
                             }
                         }
                         .listStyle(PlainListStyle())


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
검색한 다음에 목록 누르면 상세화면 내비게이션이 되지 않아서 급히 수정했습니다!


https://github.com/user-attachments/assets/334bb481-08ff-4d47-bbaa-81a7ff1eec56

